### PR TITLE
Allow mapAttribute object param to set defaults

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -34,7 +34,7 @@ export const mapAttributes = (attributes) => {
                 return null;
             }
 
-            return this.variateAttributes[key] || this.variateAttributes[val];
+            return this.variateAttributes[key] || (val || '');
         };
     });
 


### PR DESCRIPTION
Allow developers to set sensible default to Variate supported props using `mapAttributes`. 

Fixes #3 